### PR TITLE
audio: Improve tonegenerator examples

### DIFF
--- a/examples/tonegenerator/tonegenerator.ino
+++ b/examples/tonegenerator/tonegenerator.ino
@@ -1,35 +1,47 @@
 #include <USBComposite.h>
 
 uint8 val;
-unsigned long last_audio_read_ms;
+uint16 sample_rate = 8000;
+int sin_hz = 200;
+int step = 50;
+unsigned long last_micros;
 double theta;
 double inc;
 
 USBAUDIO AUDIO;
 
+double get_increment_from_hz(int hz)
+{
+  return (2 * M_PI) / ((1000000.0 / hz) / AUDIO.getSamplePeriod());
+}
+
 void setup()
 {
   theta = 0.0;
-  inc = 0.05;
 
-  AUDIO.begin(MIC_MONO);
+  AUDIO.begin(MIC_MONO, sample_rate);
 
-  last_audio_read_ms = micros();
+  inc = get_increment_from_hz(sin_hz);
+
+  last_micros = micros();
 }
 
 void loop()
 {
   unsigned long current_micros = micros();
-  unsigned long elapsed = current_micros - last_audio_read_ms;
+  unsigned long elapsed = current_micros - last_micros;
 
   if (elapsed >= AUDIO.getSamplePeriod())
   {
     theta += inc;
 
+    if (theta > M_PI * 2)
+      theta -= M_PI * 2;
+
     val = (uint8) (((sin(theta) + 1.0) / 2.0) * 255);
 
-    last_audio_read_ms = current_micros;
-
     while (!AUDIO.write(&val, 1));
+
+    last_micros = current_micros;
   }
 }

--- a/examples/tonegeneratorserial/tonegeneratorserial.ino
+++ b/examples/tonegeneratorserial/tonegeneratorserial.ino
@@ -1,6 +1,9 @@
 #include <USBComposite.h>
 
 uint8 val;
+uint16 sample_rate = 8000;
+int sin_hz = 200;
+int step = 50;
 unsigned long last_audio_read_ms;
 double theta;
 double inc;
@@ -8,12 +11,18 @@ double inc;
 USBCompositeSerial CompositeSerial;
 USBAUDIO AUDIO;
 
+double get_increment_from_hz(int hz)
+{
+  return (2 * M_PI) / ((1000000.0 / hz) / AUDIO.getSamplePeriod());
+}
+
 void setup()
 {
   theta = 0.0;
-  inc = 0.05;
 
-  AUDIO.begin(CompositeSerial, MIC_MONO);
+  AUDIO.begin(CompositeSerial, MIC_MONO, sample_rate);
+
+  inc = get_increment_from_hz(sin_hz);
 
   last_audio_read_ms = micros();
 }
@@ -27,11 +36,14 @@ void loop()
   {
     theta += inc;
 
+    if (theta > M_PI * 2)
+      theta -= M_PI * 2;
+
     val = (uint8) (((sin(theta) + 1.0) / 2.0) * 255);
 
-    last_audio_read_ms = current_micros;
-
     while (!AUDIO.write(&val, 1));
+
+    last_audio_read_ms = current_micros;
   }
 
   if (CompositeSerial.available())
@@ -39,12 +51,14 @@ void loop()
     char ch = CompositeSerial.read();
     if (ch == '+')
     {
-      inc += 0.005;
+      sin_hz += step;
+      inc = get_increment_from_hz(sin_hz);
       CompositeSerial.println(inc);
     }
     else if (ch == '-')
     {
-      inc -= 0.005;
+      sin_hz -= step;
+      inc = get_increment_from_hz(sin_hz);
       CompositeSerial.println(inc);
     }
   }


### PR DESCRIPTION
This fixes some glitches in the generated wave, mostly by lowering
the sample rate from 24000 to 8000. It also adds a function to get
the radians increment for the wave from hz, which bases off the rate.
This means it attempts to make the frequency consistent between
different sample rates but it does poorly on rates higher than 8000.