### PR TITLE
modify bootloader reset sequence

### DIFF
--- a/USBCompositeSerial.cpp
+++ b/USBCompositeSerial.cpp
@@ -22,6 +22,7 @@
 #include <libmaple/usb.h>
 #include <string.h>
 #include <libmaple/iwdg.h>
+#include <libmaple/bkp.h>
 
 #include "usb_composite_serial.h"
 
@@ -239,6 +240,12 @@ static void rxHook(unsigned hook, void *ignored) {
             }
 
             // Got the magic sequence -> reset, presumably into the bootloader.
+            // Write 0x424C to backup register 0x0A to tell the bootloader to wait
+            bkp_init();
+            bkp_enable_writes();
+            bkp_write(0x0a,0x424c);
+            bkp_disable_writes();
+
             // Return address is wait_reset, but we must set the thumb bit.
             uintptr_t target = (uintptr_t)wait_reset | 0x1;
             asm volatile("mov r0, %[stack_top]      \n\t" // Reset stack


### PR DESCRIPTION
Currently the 'reset to bootloader' function doesn't work too well with the [HID bootloader](https://github.com/Serasidis/STM32_HID_Bootloader).
The bootloader doesn't wait for an upload to start after a reset unless a 'magic word' is written to the register BKP_10 prior to reset (see http://stm32duinoforum.com/forum/viewtopic_f_16_t_1549.html).

This patch sets the backup register value to 0x424C, which signals the bootloader to stop and wait for an upload.
