### PR TITLE
Allow setting the bcdDevice field to report firmware version number

### DIFF
--- a/USBComposite.cpp
+++ b/USBComposite.cpp
@@ -5,6 +5,7 @@
 
 #define DEFAULT_VENDOR_ID  0x1EAF
 #define DEFAULT_PRODUCT_ID 0x0024
+#define DEFAULT_PRODUCT_VERSION 0x0200
 
 static char* putSerialNumber(char* out, int nibbles, uint32 id) {
     for (int i=0; i<nibbles; i++, id >>= 4) {
@@ -58,6 +59,13 @@ void USBCompositeDevice::setProductId(uint16 _productId) {
         productId = DEFAULT_PRODUCT_ID;
 }
 
+void USBCompositeDevice::setProductVersion(uint16 _version) {
+    if (_version != 0)
+        productVersion = _version;
+    else
+        productVersion = DEFAULT_PRODUCT_VERSION;
+}
+
 void USBCompositeDevice::setManufacturerString(const char* s) {
     iManufacturer = s;
 }
@@ -77,7 +85,7 @@ bool USBCompositeDevice::begin() {
 		if (init[i] != NULL && !init[i](plugin[i]))
 			return false;
 	}
-	usb_generic_set_info(vendorId, productId, iManufacturer, iProduct, iSerialNumber);
+	usb_generic_set_info(vendorId, productId, productVersion, iManufacturer, iProduct, iSerialNumber);
     if (! usb_generic_set_parts(parts, numParts))
         return false;
     usb_generic_enable();

--- a/USBComposite.h
+++ b/USBComposite.h
@@ -26,6 +26,7 @@ private:
     const char* iSerialNumber = NULL;
     uint16 vendorId;
     uint16 productId;
+    uint16 productVersion;
     USBCompositePart* parts[USB_COMPOSITE_MAX_PARTS];
     USBPartInitializer init[USB_COMPOSITE_MAX_PARTS];
     USBPartStopper stop[USB_COMPOSITE_MAX_PARTS];
@@ -36,6 +37,7 @@ public:
     USBCompositeDevice(void); 
     void setVendorId(uint16 vendor=0);
     void setProductId(uint16 product=0);
+    void setProductVersion(uint16 version=0);
     void setManufacturerString(const char* manufacturer=NULL);
     void setProductString(const char* product=NULL);
     void setSerialString(const char* serialNumber=DEFAULT_SERIAL_STRING);
@@ -64,4 +66,4 @@ extern USBCompositeDevice USBComposite;
 #include <USBMultiSerial.h>
 #include <USBXBox360.h>
 #endif
-        
+

--- a/usb_generic.c
+++ b/usb_generic.c
@@ -91,9 +91,10 @@ uint16 epTypes[4] = {
 
 #define LEAFLABS_ID_VENDOR                0x1EAF
 #define MAPLE_ID_PRODUCT                  0x0024 // was 0x0024
-#define USB_DEVICE_CLASS              	  0x00
-#define USB_DEVICE_SUBCLASS	           	  0x00
-#define DEVICE_PROTOCOL					  0x01
+#define DEFAULT_VERSION                   0x0200
+#define USB_DEVICE_CLASS                  0x00
+#define USB_DEVICE_SUBCLASS	              0x00
+#define DEVICE_PROTOCOL                   0x01
 //#define REQUEST_TYPE                      0b01100000u
 #define REQUEST_RECIPIENT                 0b00011111u
 
@@ -102,13 +103,13 @@ static usb_descriptor_device usbGenericDescriptor_Device =
       .bLength            = sizeof(usb_descriptor_device),              
       .bDescriptorType    = USB_DESCRIPTOR_TYPE_DEVICE,                 
       .bcdUSB             = 0x0200,                                     
-      .bDeviceClass       = USB_DEVICE_CLASS,                       	
-      .bDeviceSubClass    = USB_DEVICE_SUBCLASS,                    	
+      .bDeviceClass       = USB_DEVICE_CLASS,                           
+      .bDeviceSubClass    = USB_DEVICE_SUBCLASS,                        
       .bDeviceProtocol    = DEVICE_PROTOCOL,                            
       .bMaxPacketSize0    = 0x40,                                       
       .idVendor           = LEAFLABS_ID_VENDOR,                         
       .idProduct          = MAPLE_ID_PRODUCT,                           
-      .bcdDevice          = 0x0200,                                     
+      .bcdDevice          = DEFAULT_VERSION,                            
       .iManufacturer      = 0x01,                                       
       .iProduct           = 0x02,                                       
       .iSerialNumber      = 0x00,                                       
@@ -318,7 +319,7 @@ uint8 usb_generic_set_parts(USBCompositePart** _parts, unsigned _numParts) {
     return 1;
 }
 
-void usb_generic_set_info(uint16 idVendor, uint16 idProduct, const char* iManufacturer, const char* iProduct, const char* iSerialNumber) {
+void usb_generic_set_info(uint16 idVendor, uint16 idProduct, uint16 deviceVersion, const char* iManufacturer, const char* iProduct, const char* iSerialNumber) {
     if (idVendor != 0)
         usbGenericDescriptor_Device.idVendor = idVendor;
     else
@@ -329,10 +330,15 @@ void usb_generic_set_info(uint16 idVendor, uint16 idProduct, const char* iManufa
     else
         usbGenericDescriptor_Device.idProduct = MAPLE_ID_PRODUCT;
     
+    if (deviceVersion != 0)
+        usbGenericDescriptor_Device.bcdDevice = deviceVersion;
+    else
+        usbGenericDescriptor_Device.bcdDevice = DEFAULT_VERSION;
+    
     if (iManufacturer == NULL) {
         iManufacturer = DEFAULT_MANUFACTURER;
     }
-           
+    
     String_Descriptor[1].Descriptor = (uint8*)iManufacturer;
     String_Descriptor[1].Descriptor_Size = 0;
      

--- a/usb_generic.h
+++ b/usb_generic.h
@@ -129,7 +129,7 @@ static inline void usb_generic_set_tx(USBEndpointInfo* ep, uint32 length) {
 
 uint32 usb_generic_send_from_circular_buffer_double_buffered(USBEndpointInfo* ep, volatile uint8* buf, uint32 circularBufferSize, uint32 amount, volatile uint32* tailP);
 void usb_generic_set_disconnect_delay(uint32 delay);
-void usb_generic_set_info(uint16 idVendor, uint16 idProduct, const char* iManufacturer, const char* iProduct, const char* iSerialNumber);
+void usb_generic_set_info(uint16 idVendor, uint16 idProduct, uint16 deviceVersion, const char* iManufacturer, const char* iProduct, const char* iSerialNumber);
 uint8 usb_generic_set_parts(USBCompositePart** _parts, unsigned _numParts);
 void usb_generic_control_rx_setup(volatile void* buffer, uint16 length, volatile uint8* done);
 void usb_generic_control_tx_setup(volatile void* buffer, uint16 length, volatile uint8* done);


### PR DESCRIPTION
The bcdDevice field in the USB device descriptor is used to indicate the firmware version of the USB device.  It was previously hard coded to 0x0200, representing version 2.0.  This remains the default behavior, but this PR adds a new function, setProductVersion(), to allow changing this field if desired.  Its behavior should be similar to the setVendorID() and setProductVersion() functions that already exist in the library.